### PR TITLE
hotfix(build): explicitly set build > base value in nuxt.config.js

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -58,5 +58,7 @@ export default {
   },
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
-  build: {},
+  build: {
+    base: '/federated-shelby.github.io/'
+  },
 };

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -59,6 +59,6 @@ export default {
 
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {
-    base: '/federated-shelby.github.io/'
+    base: '/federated-shelby.github.io/',
   },
 };


### PR DESCRIPTION
## Explicitly set `build` > `base` value in `nuxt.config.js`

### Description

There is an issue when deploying via GitHub Pages in which the main Nuxt app call returns 200 OK, but the compiled Nuxt files and favicon requests return 400 Not Found.
Explicitly setting the Build Configuration `base` parameter value should theoretically help resolve this issue.

### Type of Change

Please mark the most-relevant option(s) with a "[x]".

- [x] **Bug Fix** (non-breaking change which fixes an issue)
- [ ] **New Feature** (non-breaking change which adds functionality)
- [ ] **Enhancement** (stylistic or minor changes that optimizes the project in some way)
- [ ] **Breaking change** (fix/feature that causes existing functionality to not work as expected)
- [ ] **Documentation** (documentation update, whether in README or code comments)

### Checklist

Please review all the steps below before finalizing the pull request.

- [x] I have performed a self-review of my own code
- [x] All new/existing unit tests pass locally
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (if necessary)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

### Attachments
200 OK response for call to access web application entry point:
<img width="1261" alt="Screenshot 2024-08-17 at 12 50 14 PM" src="https://github.com/user-attachments/assets/110cd73e-3d68-4d6b-a26b-df77495c2324">

404 Not Found response for  call to get favicon and compiled Nuxt application files:
<img width="1216" alt="Screenshot 2024-08-17 at 12 52 07 PM" src="https://github.com/user-attachments/assets/75a3c4b5-1c9b-4c23-acc3-d72a1e56c41f">

### Additional Context

See "Attachments" section (above)